### PR TITLE
[Gluon] Expose `ttg.warp_specialize` (#6989)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -468,7 +468,9 @@ def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
   let builders = [
     OpBuilder<(ins "TypeRange":$resultTypes,
                    "ArrayRef<int32_t>":$partitionNumWarps,
-                   "unsigned":$numPartitionRegions)>
+                   "unsigned":$numPartitionRegions)>,
+    OpBuilder<(ins "TypeRange":$resultTypes, "ValueRange":$explicitCaptures,
+                   "ArrayRef<int32_t>":$partitionNumWarps)>,
   ];
 
   let hasVerifier = 1;

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -886,6 +886,13 @@ void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
                                              partitionNumRegions);
 }
 
+void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
+                             TypeRange resultTypes, ValueRange explicitCaptures,
+                             ArrayRef<int32_t> partitionNumWarps) {
+  build(builder, state, resultTypes, explicitCaptures, partitionNumWarps, {},
+        {}, {});
+}
+
 ParseResult WarpSpecializeOp::parse(OpAsmParser &p, OperationState &result) {
   SmallVector<OpAsmParser::UnresolvedOperand> operands;
   SMLoc operandLoc = p.getCurrentLocation();

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -382,7 +382,11 @@ void init_triton_ir(py::module &&m) {
       .def("get_parent_region", &Region::getParentRegion, ret::reference)
       .def("size", [](Region &self) { return self.getBlocks().size(); })
       .def("empty", &Region::empty)
-      .def("id", [](Region &self) { return (uint64_t)&self; });
+      .def("id", [](Region &self) { return (uint64_t)&self; })
+      .def("push_back",
+           [](Region &self, Block *block) { self.push_back(block); })
+      .def("push_front",
+           [](Region &self, Block *block) { self.push_front(block); });
 
   py::class_<Block>(m, "block", py::module_local())
       .def("arg",
@@ -492,13 +496,23 @@ void init_triton_ir(py::module &&m) {
              self->print(os, printingFlags);
              return str;
            })
+      .def("str_nodebug",
+           [](OpState &self) -> std::string {
+             std::string str;
+             llvm::raw_string_ostream os(str);
+             self->print(os);
+             return str;
+           })
       .def("append_operand",
            [](OpState &self, Value &val) {
              self->insertOperands(self->getNumOperands(), val);
            })
-      .def("verify", [](OpState &self) -> bool {
-        return succeeded(verify(self.getOperation()));
-      });
+      .def("verify",
+           [](OpState &self) -> bool {
+             return succeeded(verify(self.getOperation()));
+           })
+      .def("get_operation", [](OpState &self) { return self.getOperation(); });
+
   // scf Ops
   py::class_<scf::ForOp, OpState>(m, "ForOp", py::module_local())
       .def("get_induction_var", &scf::ForOp::getInductionVar);

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -1,114 +1,15 @@
-import sys
-import os
-import io
-import inspect
-
-from filecheck.options import Options
-from filecheck.finput import FInput
-from filecheck.parser import Parser, pattern_for_opts
-from filecheck.matcher import Matcher
-
 import triton
 import triton.language as tl
-from triton.compiler import ASTSource, make_backend
-from triton.backends.compiler import GPUTarget
-from triton._C.libtriton import ir
-
-import pytest
+from triton._filecheck import filecheck_test
 
 # ===-----------------------------------------------------------------------===#
-# filecheck_test
+# Unit Tests
 # ===-----------------------------------------------------------------------===#
-
-# Stub target for testing the frontend.
-stub_target = GPUTarget("cuda", 100, 32)
-stub_backend = make_backend(stub_target)
-
-llvm_bin_dir = os.path.join(os.path.dirname(sys.executable), "bin")
-filecheck_path = os.path.join(llvm_bin_dir, "FileCheck")
-
-
-def run_filecheck(name, module_str, check_template):
-    options = Options(match_filename=name)
-    fin = FInput(name, module_str)
-    ops = io.StringIO(check_template)
-    parser = Parser(options, ops, *pattern_for_opts(options))
-    matcher = Matcher(options, fin, parser)
-    matcher.stderr = io.StringIO()
-    if matcher.run() != 0:
-        raise ValueError(matcher.stderr.getvalue())
-
-
-def run_parser(kernel_fn):
-    sigkeys = [x.name for x in kernel_fn.params]
-    sigvals = [f"arg{i}" for i in range(len(sigkeys))]
-    signature = {k: v for (k, v) in zip(sigkeys, sigvals)}
-    src = ASTSource(fn=kernel_fn, signature=signature)
-
-    context = ir.context()
-    ir.load_dialects(context)
-    stub_backend.load_dialects(context)
-
-    extra_options = src.parse_options()
-    options = stub_backend.parse_options(dict(**extra_options))
-    codegen_fns = stub_backend.get_codegen_implementation(options)
-    module_map = stub_backend.get_module_map()
-    return src.make_ir(options, codegen_fns, module_map, context)
-
-
-def run_filecheck_test(kernel_fn):
-    assert isinstance(kernel_fn, triton.runtime.JITFunction)
-    check_template = inspect.getsource(kernel_fn.fn)
-    if check_template is None:
-        raise ValueError("kernel function must have a docstring with FileCheck template")
-    mlir_module = run_parser(kernel_fn)
-
-    run_filecheck("placeholder", str(mlir_module), check_template)
 
 
 @triton.jit
 def anchor(v):
     pass
-
-
-# Smoke test to make sure filecheck is working correctly.
-def test_filecheck_positive():
-
-    @triton.jit
-    def test_kernel():
-        # CHECK-LABEL: test_kernel
-        scalar = 42
-        # CHECK: %c42_i32 = arith.constant 42 : i32
-        # CHECK-NEXT: call @anchor{{.*}}(%c42_i32) : (i32) -> ()
-        anchor(scalar)
-
-    run_filecheck_test(test_kernel)
-
-
-def test_filecheck_negative():
-
-    @triton.jit
-    def test_kernel():
-        # CHECK-LABEL: test_kernel
-        scalar = 11
-        # CHECK: %c42_i32
-        anchor(scalar)
-
-    with pytest.raises(ValueError, match="Couldn't match \"%c42_i32\""):
-        run_filecheck_test(test_kernel)
-
-
-def filecheck_test(fn):
-
-    def test_fn():
-        run_filecheck_test(fn)
-
-    return test_fn
-
-
-# ===-----------------------------------------------------------------------===#
-# Unit Tests
-# ===-----------------------------------------------------------------------===#
 
 
 @tl.core._aggregate

--- a/python/test/unit/test_filecheck.py
+++ b/python/test/unit/test_filecheck.py
@@ -1,0 +1,36 @@
+import pytest
+import triton
+
+from triton._filecheck import run_filecheck_test
+
+
+@triton.jit
+def anchor(v):
+    pass
+
+
+# Smoke test to make sure filecheck is working correctly.
+def test_filecheck_positive():
+
+    @triton.jit
+    def test_kernel():
+        # CHECK-LABEL: test_kernel
+        scalar = 42
+        # CHECK: %c42_i32 = arith.constant 42 : i32
+        # CHECK-NEXT: call @anchor{{.*}}(%c42_i32) : (i32) -> ()
+        anchor(scalar)
+
+    run_filecheck_test(test_kernel)
+
+
+def test_filecheck_negative():
+
+    @triton.jit
+    def test_kernel():
+        # CHECK-LABEL: test_kernel
+        scalar = 11
+        # CHECK: %c42_i32
+        anchor(scalar)
+
+    with pytest.raises(ValueError, match="Couldn't match \"%c42_i32\""):
+        run_filecheck_test(test_kernel)

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -25,6 +25,7 @@ from .runtime._allocation import set_allocator
 from . import language
 from . import testing
 from . import tools
+from ._filecheck import run_filecheck_test, filecheck_test, run_parser
 
 must_use_result = language.core.must_use_result
 
@@ -51,6 +52,9 @@ __all__ = [
     "TritonError",
     "testing",
     "tools",
+    "run_filecheck_test",
+    "filecheck_test",
+    "run_parser",
 ]
 
 # -------------------------------------

--- a/python/triton/_filecheck.py
+++ b/python/triton/_filecheck.py
@@ -1,0 +1,81 @@
+import sys
+import os
+import io
+import inspect
+
+from filecheck.options import Options
+from filecheck.finput import FInput
+from filecheck.parser import Parser, pattern_for_opts
+from filecheck.matcher import Matcher
+
+import triton
+from triton.compiler import ASTSource, make_backend
+from triton.backends.compiler import GPUTarget
+from triton._C.libtriton import ir
+
+# ===-----------------------------------------------------------------------===#
+# filecheck_test
+# ===-----------------------------------------------------------------------===#
+
+# Stub target for testing the frontend.
+stub_target = GPUTarget("cuda", 100, 32)
+stub_backend = make_backend(stub_target)
+
+llvm_bin_dir = os.path.join(os.path.dirname(sys.executable), "bin")
+filecheck_path = os.path.join(llvm_bin_dir, "FileCheck")
+
+
+class MatchError(ValueError):
+
+    def __init__(self, message, module_str):
+        super().__init__(message)
+        self.module_str = module_str
+
+    def __str__(self):
+        return f"{super().__str__()}\n{self.module_str}"
+
+
+def run_filecheck(name, module_str, check_template):
+    options = Options(match_filename=name)
+    fin = FInput(name, module_str)
+    ops = io.StringIO(check_template)
+    parser = Parser(options, ops, *pattern_for_opts(options))
+    matcher = Matcher(options, fin, parser)
+    matcher.stderr = io.StringIO()
+    if matcher.run() != 0:
+        raise MatchError(matcher.stderr.getvalue(), module_str)
+
+
+def run_parser(kernel_fn):
+    sigkeys = [x.name for x in kernel_fn.params]
+    sigvals = [f"arg{i}" for i in range(len(sigkeys))]
+    signature = {k: v for (k, v) in zip(sigkeys, sigvals)}
+    src = ASTSource(fn=kernel_fn, signature=signature)
+
+    context = ir.context()
+    ir.load_dialects(context)
+    stub_backend.load_dialects(context)
+
+    extra_options = src.parse_options()
+    options = stub_backend.parse_options(dict(**extra_options))
+    codegen_fns = stub_backend.get_codegen_implementation(options)
+    module_map = stub_backend.get_module_map()
+    return src.make_ir(options, codegen_fns, module_map, context)
+
+
+def run_filecheck_test(kernel_fn):
+    assert isinstance(kernel_fn, triton.runtime.JITFunction)
+    check_template = inspect.getsource(kernel_fn.fn)
+    if check_template is None:
+        raise ValueError("kernel function must have a docstring with FileCheck template")
+    mlir_module = run_parser(kernel_fn)
+
+    run_filecheck("placeholder", mlir_module.str_nodebug(), check_template)
+
+
+def filecheck_test(fn):
+
+    def test_fn():
+        run_filecheck_test(fn)
+
+    return test_fn

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -79,6 +79,7 @@ __all__ = [
     "convert_layout",
     "allocate_shared",
     "shared_memory_descriptor",
+    "warp_specialize",
 ]
 
 T = TypeVar("T")
@@ -233,3 +234,13 @@ def allocate_shared(element_ty, shape, layout, value=None, _builder=None):
     shape = _unwrap_if_constexpr(shape)
     layout = _unwrap_if_constexpr(layout)
     return semantic.allocate_shared(element_ty, shape, layout, value, _builder)
+
+
+@builtin
+def warp_specialize(args, default_partition, worker_partitions, worker_num_warps, worker_num_regs,  #
+                    _builder=None, _generator=None):
+    worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
+    worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
+    args = [_unwrap_if_constexpr(arg) for arg in args]
+    return semantic.warp_specialize(args, default_partition, worker_partitions, worker_num_warps,  #
+                                    worker_num_regs, _builder, _generator)

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -1,6 +1,8 @@
+from typing import Sequence
 from triton.language import semantic as tl_semantic
 from . import _core as ttgl
 from triton._C.libtriton.gluon_ir import GluonOpBuilder
+from triton.compiler.code_generator import flatten_values_to_ir, unflatten_ir_values
 
 
 def arange(start, end, layout, builder: GluonOpBuilder):
@@ -42,3 +44,44 @@ def shared_load(mem_desc, layout, builder: GluonOpBuilder):
 
 def shared_store(mem_desc, value, builder: GluonOpBuilder):
     builder.create_local_store(mem_desc.handle, value.handle)
+
+
+def warp_specialize(args, default_partition, worker_partitions, worker_num_warps: Sequence[int],
+                    worker_num_regs: Sequence[int], builder: GluonOpBuilder, generator):
+    num_partitions = len(worker_partitions)
+    assert num_partitions == len(
+        worker_num_warps), f"warp specialize got {num_partitions} partitions but {len(worker_num_warps)} warp counts"
+    assert num_partitions == len(
+        worker_num_regs), f"warp specialize got {num_partitions} partitions but {len(worker_num_regs)} register counts"
+
+    insert_pt = builder.get_insertion_point()
+
+    # Emit the default partition to get the result types.
+    default_block = builder.new_block()
+    builder.set_insertion_point_to_start(default_block)
+    default_results = generator.call_JitFunction(default_partition, args, kwargs={})
+    mlir_results = flatten_values_to_ir(default_results)
+    builder.create_warp_yield(mlir_results)
+    result_types = [r.get_type() for r in mlir_results]
+
+    # Create the warp specialize op.
+    builder.restore_insertion_point(insert_pt)
+    mlir_args = flatten_values_to_ir(args)
+    ws_op = builder.create_warp_specialize(result_types, mlir_args, worker_num_warps)
+    ws_op.get_default_region().push_back(default_block)
+    ws_op.set_requested_registers(worker_num_regs)
+
+    # Emit the partition regions.
+    builder.create_block_with_parent(ws_op.get_partition_op_holder(), [])
+    partitions_op = builder.create_warp_specialize_partitions(num_partitions)
+    arg_types = [arg.get_type() for arg in mlir_args]
+    for i in range(num_partitions):
+        block = builder.create_block_with_parent(partitions_op.get_region(i), arg_types)
+        block_args = [block.get_argument(j) for j in range(len(mlir_args))]
+        block_args = unflatten_ir_values(block_args, [arg.type for arg in args])
+        generator.call_JitFunction(worker_partitions[i], block_args, kwargs={})
+        builder.create_warp_return()
+
+    builder.set_insertion_point_after(ws_op.get_operation())
+    mlir_results = [ws_op.get_result(i) for i in range(len(result_types))]
+    return tuple(unflatten_ir_values(mlir_results, [r.type for r in default_results]))


### PR DESCRIPTION
📚 Stack PRs 📚

1. https://github.com/triton-lang/triton/pull/6988
2. ➡️ https://github.com/triton-lang/triton/pull/6989

This PR adds a function to expose `ttg.warp_specialize` as a list of functions, where the default function is allowed to return values that are passed through the default region. It also moves the filecheck testing to a common package to be used across various unit tests.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
